### PR TITLE
Remove unnecessary logging lines

### DIFF
--- a/spline-curve.js
+++ b/spline-curve.js
@@ -21,7 +21,6 @@ module.exports = function(RED) {
 
         var node = this;
         node.on('input', function(msg){
-            console.log(config);
             const input_key  = (config.input_key)?config.input_key:"payload";
             const output_key = (config.output_key)?config.output_key:"payload";
             const inputKeys  = input_key.split(".");
@@ -33,7 +32,6 @@ module.exports = function(RED) {
             }
 
             const result = curve.getValueAt(inputValue);
-            console.log(outputKeys);
             iterableAssignment(msg, outputKeys, result);
             node.send(msg);
         });


### PR DESCRIPTION
There are two lines that output a bunch of debugging information from this node. While I understand that this may be nice for development, it generates way too much output for end users. I'd suggest either removing these lines altogether or adding a flag or env var (which is off by default) to enable debug logging. 
This PR removes these lines.